### PR TITLE
Handle new item state endpoints

### DIFF
--- a/unnamedcast.xcodeproj/project.pbxproj
+++ b/unnamedcast.xcodeproj/project.pbxproj
@@ -50,6 +50,10 @@
 		839680C41CACBDBA007A4D62 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E345751C94ADAB009F25E6 /* User.swift */; };
 		839680C51CACBDBA007A4D62 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833239B21C78E2DD00494388 /* Endpoint.swift */; };
 		839680C71CACBDBA007A4D62 /* SyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83AFF8A91C8B7A8900E94AFE /* SyncEngine.swift */; };
+		83AC3EAE1CEFEC93000F00F4 /* NSDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83AC3EAD1CEFEC93000F00F4 /* NSDate.swift */; };
+		83AC3EAF1CEFEC93000F00F4 /* NSDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83AC3EAD1CEFEC93000F00F4 /* NSDate.swift */; };
+		83AC3EB01CEFEC93000F00F4 /* NSDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83AC3EAD1CEFEC93000F00F4 /* NSDate.swift */; };
+		83AC3EB11CEFEC93000F00F4 /* NSDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83AC3EAD1CEFEC93000F00F4 /* NSDate.swift */; };
 		83AFF8AA1C8B7A8900E94AFE /* SyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83AFF8A91C8B7A8900E94AFE /* SyncEngine.swift */; };
 		83C5145A1CACC931003FCBA4 /* feed1.json in Resources */ = {isa = PBXBuildFile; fileRef = 83E345631C94A5FE009F25E6 /* feed1.json */; };
 		83E345641C94A5FE009F25E6 /* feed1.json in Resources */ = {isa = PBXBuildFile; fileRef = 83E345631C94A5FE009F25E6 /* feed1.json */; };
@@ -107,6 +111,7 @@
 		837857C51C5D629B0026959C /* PlayerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayerViewController.swift; sourceTree = "<group>"; };
 		837857D21C5D93600026959C /* UIImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImage.swift; sourceTree = "<group>"; };
 		839680BC1CA74A4F007A4D62 /* PlayerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayerView.swift; sourceTree = "<group>"; };
+		83AC3EAD1CEFEC93000F00F4 /* NSDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDate.swift; sourceTree = "<group>"; };
 		83AFF8A91C8B7A8900E94AFE /* SyncEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncEngine.swift; sourceTree = "<group>"; };
 		83C85B961CACC9E3001FF216 /* Pods_unnamedcastTests.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Pods_unnamedcastTests.framework; path = "Pods/../build/Debug-iphoneos/Pods_unnamedcastTests.framework"; sourceTree = "<group>"; };
 		83E345631C94A5FE009F25E6 /* feed1.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = feed1.json; path = ../unnamedcastTests/feed1.json; sourceTree = "<group>"; };
@@ -224,6 +229,7 @@
 			isa = PBXGroup;
 			children = (
 				837857D21C5D93600026959C /* UIImage.swift */,
+				83AC3EAD1CEFEC93000F00F4 /* NSDate.swift */,
 			);
 			name = Foundation;
 			sourceTree = "<group>";
@@ -655,6 +661,7 @@
 				8364FB031CE41B36004576F7 /* Array.swift in Sources */,
 				835177241CE6B0E200064843 /* Player.swift in Sources */,
 				835793A81CE00E79003F09FA /* DB.swift in Sources */,
+				83AC3EB11CEFEC93000F00F4 /* NSDate.swift in Sources */,
 				839680C31CACBDBA007A4D62 /* Feed.swift in Sources */,
 				839680C41CACBDBA007A4D62 /* User.swift in Sources */,
 				839680C51CACBDBA007A4D62 /* Endpoint.swift in Sources */,
@@ -682,6 +689,7 @@
 				833239B31C78E2DD00494388 /* Endpoint.swift in Sources */,
 				8377B5131CE64C8000B32588 /* ApplicationDelegateReachable.swift in Sources */,
 				830130481CE56BCC00E583DF /* APIClient.swift in Sources */,
+				83AC3EAE1CEFEC93000F00F4 /* NSDate.swift in Sources */,
 				833F1B111C5B01AE002CCB77 /* FeedViewController.swift in Sources */,
 				837857C01C5C52400026959C /* Player.swift in Sources */,
 				83475B2A1C62DB5000F48D33 /* AppContainerViewController.swift in Sources */,
@@ -704,6 +712,7 @@
 				83E725811C5AEF0D00A0E8D4 /* unnamedcastTests.swift in Sources */,
 				830130491CE56BCC00E583DF /* APIClient.swift in Sources */,
 				830130441CE42AC600E583DF /* SearchResult.swift in Sources */,
+				83AC3EAF1CEFEC93000F00F4 /* NSDate.swift in Sources */,
 				8364FB011CE41B36004576F7 /* Array.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -716,6 +725,7 @@
 				83E7258C1C5AEF0D00A0E8D4 /* unnamedcastUITests.swift in Sources */,
 				8301304A1CE56BCC00E583DF /* APIClient.swift in Sources */,
 				830130451CE42AC600E583DF /* SearchResult.swift in Sources */,
+				83AC3EB01CEFEC93000F00F4 /* NSDate.swift in Sources */,
 				8364FB021CE41B36004576F7 /* Array.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/unnamedcast/AppContainerViewController.swift
+++ b/unnamedcast/AppContainerViewController.swift
@@ -131,9 +131,16 @@ class AppContainerViewController: UIViewController, UINavigationControllerDelega
     let items = db.items.filter("id = %@", playerItem.id)
     guard let item = items.first else { return }
     
-    if player.isPlaying() && player.position > 0 {
-//      updateProgressBar(player.position)
-//      datastore.updateItemState(item, progress: Double(player.position)) {}
+    let pos = player.position
+    
+    if player.isPlaying() {
+      dispatch_async(dispatch_get_main_queue()) {
+//        self.updateProgressBar(self.player.position)
+        
+        try! self.db.write {
+          self.db.itemWithID(item.id)?.state = State.InProgress(position: Double(pos))
+        }
+      }
     }
     
     miniPlayerTitleLabel.text = item.title

--- a/unnamedcast/AppContainerViewController.swift
+++ b/unnamedcast/AppContainerViewController.swift
@@ -138,7 +138,7 @@ class AppContainerViewController: UIViewController, UINavigationControllerDelega
 //        self.updateProgressBar(self.player.position)
         
         try! self.db.write {
-          self.db.itemWithID(item.id)?.state = State.InProgress(position: Double(pos))
+          self.db.itemWithID(item.id)?.state = .InProgress(position: Double(pos))
         }
       }
     }

--- a/unnamedcast/Endpoint.swift
+++ b/unnamedcast/Endpoint.swift
@@ -140,10 +140,19 @@ struct GetUserEndpoint: Endpoint {
 
 struct GetUserItemStates: Endpoint {
   var userID: String
+  var modifiedSince: NSDate?
   
   let method = "GET"
   var path: String {
     return "/api/users/\(userID)/states"
+  }
+  
+  var queryParameters: [String : String?] {
+    if let d = modifiedSince {
+      return ["modified_since": rfc3339Formatter.stringFromDate(d)]
+    }
+    
+    return [:]
   }
   
   func unmarshalResponse(body: NSData) throws -> [ItemState] {
@@ -180,6 +189,22 @@ struct UpdateUserItemStatesEndpoint: Endpoint {
   
   func marshalRequestBody() throws -> NSData? {
     return try states.toJSON().serialize()
+  }
+}
+
+struct UpdateUserItemStateEndpoint: Endpoint {
+  typealias ResponseType = Void
+  
+  var userID: String
+  var state: ItemState
+  
+  let method = "PUT"
+  var path: String {
+    return "/api/users/\(userID)/states/\(state.itemID)"
+  }
+  
+  func marshalRequestBody() throws -> NSData? {
+    return try state.toJSON().serialize()
   }
 }
 

--- a/unnamedcast/Endpoint.swift
+++ b/unnamedcast/Endpoint.swift
@@ -176,22 +176,6 @@ struct UpdateUserFeedsEndpoint: Endpoint {
   }
 }
 
-struct UpdateUserItemStatesEndpoint: Endpoint {
-  typealias ResponseType = Void
-  
-  var userID: String
-  var states: [ItemState]
-  
-  let method = "PUT"
-  var path: String {
-    return "/api/users/\(userID)/states"
-  }
-  
-  func marshalRequestBody() throws -> NSData? {
-    return try states.toJSON().serialize()
-  }
-}
-
 struct UpdateUserItemStateEndpoint: Endpoint {
   typealias ResponseType = Void
   
@@ -205,18 +189,6 @@ struct UpdateUserItemStateEndpoint: Endpoint {
   
   func marshalRequestBody() throws -> NSData? {
     return try state.toJSON().serialize()
-  }
-}
-
-struct DeleteUserItemStateEndpoint: Endpoint {
-  typealias ResponseType = Void
-  
-  var userID: String
-  var itemID: String
-  
-  let method = "DELETE"
-  var path: String {
-    return "/api/users/\(userID)/states/\(itemID)"
   }
 }
 

--- a/unnamedcast/Endpoint.swift
+++ b/unnamedcast/Endpoint.swift
@@ -208,6 +208,18 @@ struct UpdateUserItemStateEndpoint: Endpoint {
   }
 }
 
+struct DeleteUserItemStateEndpoint: Endpoint {
+  typealias ResponseType = Void
+  
+  var userID: String
+  var itemID: String
+  
+  let method = "DELETE"
+  var path: String {
+    return "/api/users/\(userID)/states/\(itemID)"
+  }
+}
+
 struct SearchFeedsEndpoint: Endpoint {
   var query: String
   

--- a/unnamedcast/Feed.swift
+++ b/unnamedcast/Feed.swift
@@ -60,13 +60,13 @@ class Feed: Object, JSONDecodable {
   }
 }
 
-enum State {
-  case Played
-  case Unplayed
-  case InProgress(position: Double)
-}
-
 class Item: Object, JSONDecodable {
+  enum State {
+    case Played
+    case Unplayed
+    case InProgress(position: Double)
+  }
+  
   dynamic var id: String = ""
   dynamic var guid: String = ""
   dynamic var link: String = ""

--- a/unnamedcast/Feed.swift
+++ b/unnamedcast/Feed.swift
@@ -90,7 +90,7 @@ class Item: Object, JSONDecodable {
   }
   
   override static func indexedProperties() -> [String] {
-    return ["guid"]
+    return ["stateModificationTime"]
   }
   
   var state: State {

--- a/unnamedcast/Feed.swift
+++ b/unnamedcast/Feed.swift
@@ -104,8 +104,6 @@ class Item: Object, JSONDecodable {
       return .Played
     }
     set(newValue) {
-      print("state was set: \(newValue)")
-      
       switch(newValue) {
       case .Unplayed:
         playing = true

--- a/unnamedcast/Feed.swift
+++ b/unnamedcast/Feed.swift
@@ -82,6 +82,7 @@ class Item: Object, JSONDecodable {
   dynamic var playing: Bool = false
   dynamic var feed: Feed?
   dynamic var modificationDate: NSDate?
+  dynamic var stateModificationTime: NSDate?
   let position = RealmOptional<Double>()
   
   override static func primaryKey() -> String? {
@@ -103,6 +104,8 @@ class Item: Object, JSONDecodable {
       return .Played
     }
     set(newValue) {
+      print("state was set: \(newValue)")
+      
       switch(newValue) {
       case .Unplayed:
         playing = true
@@ -114,6 +117,8 @@ class Item: Object, JSONDecodable {
         playing = true
         self.position.value = position
       }
+      
+      self.stateModificationTime = NSDate()
     }
   }
   

--- a/unnamedcast/NSDate.swift
+++ b/unnamedcast/NSDate.swift
@@ -1,0 +1,21 @@
+//
+//  NSDate.swift
+//  unnamedcast
+//
+//  Created by Christopher Lucas on 5/20/16.
+//  Copyright © 2016 Christopher Lucas. All rights reserved.
+//
+
+import Foundation
+
+func <(lhs: NSDate, rhs: NSDate) -> Bool {
+  return lhs.compare(rhs) == .OrderedAscending
+}
+
+func >(lhs: NSDate, rhs: NSDate) -> Bool {
+  return lhs.compare(rhs) == .OrderedDescending
+}
+
+func ==(lhs: NSDate, rhs: NSDate) -> Bool {
+  return lhs.compare(rhs) == .OrderedSame
+}

--- a/unnamedcast/SyncEngine.swift
+++ b/unnamedcast/SyncEngine.swift
@@ -79,9 +79,7 @@ class SyncEngine {
           continue
         }
         
-        item.state = state.itemPos.isZero
-          ? .Unplayed
-          : .InProgress(position: state.itemPos)
+        item.state = state.state
         
         // Clear state modification time to prevent uploadUserStates
         // from uploading states that were just fetched
@@ -107,17 +105,8 @@ class SyncEngine {
             fatalError("stateModificationTime is nil")
           }
           
-          switch item.state {
-          case .Played:
-            return self.requester.request(DeleteUserItemStateEndpoint(userID: self.userID, itemID: item.id))
-          case .Unplayed:
-            // stateModificationTime is guaranteed to be non-nil because of filter
-            let state = ItemState(itemID: item.id, pos: 0, modificationTime: stateModTime)
-            return self.requester.request(UpdateUserItemStateEndpoint(userID: self.userID, state: state))
-          case .InProgress(let pos):
-            let state = ItemState(itemID: item.id, pos: pos, modificationTime: stateModTime)
-            return self.requester.request(UpdateUserItemStateEndpoint(userID: self.userID, state: state))
-          }
+          let state = ItemState(itemID: item.id, state: item.state, modificationTime: stateModTime)
+          return self.requester.request(UpdateUserItemStateEndpoint(userID: self.userID, state: state))
       }
       
       print([

--- a/unnamedcast/SyncEngine.swift
+++ b/unnamedcast/SyncEngine.swift
@@ -130,11 +130,7 @@ class SyncEngine {
     }.then(on: backgroundQueue) { states in
       try self.saveUserStates(states)
     }.then(on: backgroundQueue) {
-      if self.lastSyncedTime != nil {
-        return self.uploadItemStates()
-      }
-      
-      return dispatch_promise {}
+      return self.uploadItemStates()
     }
   }
   

--- a/unnamedcast/SyncEngine.swift
+++ b/unnamedcast/SyncEngine.swift
@@ -63,8 +63,7 @@ class SyncEngine {
   }
   
   func fetchUserStates() -> Promise<[ItemState]> {
-    let ep = GetUserItemStates(userID: userID,
-                               modifiedSince: lastSyncedTime?.dateByAddingTimeInterval(1))
+    let ep = GetUserItemStates(userID: userID, modifiedSince: lastSyncedTime)
     return requester.request(ep).then { _, _, states in return states }
   }
   
@@ -102,7 +101,7 @@ class SyncEngine {
       let db = try self.newDB()
       
       let promises = db.items
-        .filter("stateModificationTime > %@", lastSyncedTime.dateByAddingTimeInterval(1) )
+        .filter("stateModificationTime > %@", lastSyncedTime)
         .map { item -> Promise<(NSURLRequest, NSHTTPURLResponse)> in
           guard let stateModTime = item.stateModificationTime else {
             fatalError("stateModificationTime is nil")

--- a/unnamedcast/User.swift
+++ b/unnamedcast/User.swift
@@ -32,30 +32,28 @@ class User: JSONDecodable {
 }
 
 class ItemState: JSONDecodable, JSONEncodable {
-  var feedID: String!
-  var itemGUID: String!
+  var itemID: String!
   var itemPos: Double!
-  
+  var modificationTime: NSDate?
+
   convenience init(item: Item, pos: Double) {
     self.init()
     
-    feedID = item.feed?.id
-    itemGUID = item.guid
+    itemID = item.id
     itemPos = pos
   }
   
   convenience required init(json: JSON) throws {
     self.init()
     
-    feedID = try json.string("feed_id")
-    itemGUID = try json.string("item_guid")
+    itemID = try json.string("item_id")
     itemPos = try json.double("position")
+    modificationTime = try rfc3339Formatter.dateFromString(json.string("modification_time"))
   }
  
   func toJSON() -> JSON {
     return [
-      "feed_id": feedID.toJSON(),
-      "item_guid": itemGUID.toJSON(),
+      "item_id": itemID.toJSON(),
       "position": itemPos.toJSON()
     ]
   }

--- a/unnamedcast/User.swift
+++ b/unnamedcast/User.swift
@@ -36,10 +36,10 @@ class ItemState: JSONDecodable, JSONEncodable {
   var itemPos: Double!
   var modificationTime: NSDate?
 
-  convenience init(item: Item, pos: Double) {
+  convenience init(itemID: String, pos: Double) {
     self.init()
     
-    itemID = item.id
+    self.itemID = itemID
     itemPos = pos
   }
   

--- a/unnamedcast/User.swift
+++ b/unnamedcast/User.swift
@@ -34,13 +34,14 @@ class User: JSONDecodable {
 class ItemState: JSONDecodable, JSONEncodable {
   var itemID: String!
   var itemPos: Double!
-  var modificationTime: NSDate?
+  var modificationTime: NSDate!
 
-  convenience init(itemID: String, pos: Double) {
+  convenience init(itemID: String, pos: Double, modificationTime: NSDate) {
     self.init()
     
     self.itemID = itemID
     itemPos = pos
+    self.modificationTime = modificationTime
   }
   
   convenience required init(json: JSON) throws {
@@ -48,13 +49,20 @@ class ItemState: JSONDecodable, JSONEncodable {
     
     itemID = try json.string("item_id")
     itemPos = try json.double("position")
-    modificationTime = try rfc3339Formatter.dateFromString(json.string("modification_time"))
+    
+    let modTime = try json.string("modification_time")
+    if let d = rfc3339Formatter.dateFromString(modTime) {
+      modificationTime = d
+    } else {
+      throw JSON.Error.ValueNotConvertible(value: JSON.String(modTime), to: NSDate.self)
+    }
   }
  
   func toJSON() -> JSON {
     return [
       "item_id": itemID.toJSON(),
-      "position": itemPos.toJSON()
+      "position": itemPos.toJSON(),
+      "modification_time": rfc3339Formatter.stringFromDate(modificationTime).toJSON()
     ]
   }
 }

--- a/unnamedcast/User.swift
+++ b/unnamedcast/User.swift
@@ -81,7 +81,7 @@ class ItemState: JSONDecodable, JSONEncodable {
       state = 1
       position = pos
     case .Played:
-      state = 3
+      state = 2
     }
     
     return [

--- a/unnamedcast/User.swift
+++ b/unnamedcast/User.swift
@@ -51,7 +51,7 @@ class ItemState: JSONDecodable, JSONEncodable {
     itemPos = try json.double("position")
     
     let modTime = try json.string("modification_time")
-    if let d = rfc3339Formatter.dateFromString(modTime) {
+    if let d = parseDate(modTime) {
       modificationTime = d
     } else {
       throw JSON.Error.ValueNotConvertible(value: JSON.String(modTime), to: NSDate.self)

--- a/unnamedcastUnitTests/unnamedcastUnitTests.swift
+++ b/unnamedcastUnitTests/unnamedcastUnitTests.swift
@@ -555,3 +555,94 @@ class unnamedcastUnitTests: XCTestCase {
     }
   }
 }
+
+func ==(lhs: Item.State, rhs: Item.State) -> Bool {
+  switch (lhs, rhs) {
+  case (.Unplayed, .Unplayed):
+    return true
+  case (.InProgress(let lhsPos), .InProgress(let rhsPos)):
+    return lhsPos == rhsPos
+  case (.Played, .Played):
+    return true
+  default:
+    return false
+  }
+}
+
+class testItemStateSync: XCTestCase {
+  let dbc = DB.Configuration(realmConfig: Realm.Configuration(
+    inMemoryIdentifier: "testItemStateSync",
+    deleteRealmIfMigrationNeeded: true
+    ))
+  var db: DB!
+  
+  let userID = "56d65493c8747268f348438d"
+  let feedID = "56d65493c8747268f348438e"
+  
+  override func setUp() {
+    super.setUp()
+    continueAfterFailure = false
+    
+    db = try! DB(configuration: dbc)
+    try! db.deleteAll()
+    
+    NSUserDefaults.resetStandardUserDefaults()
+    
+    let feed = Feed()
+    feed.id = feedID
+    
+    try! db.write {
+      self.db.add(feed)
+    }
+  }
+  
+  func newSyncEngine(requester: MockRequester) -> SyncEngine {
+    let conf = SyncEngine.Configuration(dbConfiguration: dbc,
+                                        endpointRequester: requester)
+    return SyncEngine(configuration: conf)
+  }
+
+  
+  func addItem(item: Item) {
+    try! db.write {
+      item.feed = self.db.feedWithID(self.feedID)
+      self.db.add(item)
+    }
+  }
+  
+  func testFetch() {
+    let item = Item()
+    item.id = "56d65493c8747268f348438f"
+    addItem(item)
+    
+    let requester = MockRequester()
+    
+    requester.registerResponse("GET",
+                               path: "/api/users/\(userID)/states",
+                               response: JSON.Array([
+                                [
+                                  "item_id": "56d65493c8747268f348438f",
+                                  "state": 1,
+                                  "position": 5.5,
+                                  "modification_time": "2016-04-03T19:38:03.33Z",
+                                ]
+                               ]))
+    
+    let expectation = expectationWithDescription("")
+
+    let engine = newSyncEngine(requester)
+    engine.userID = userID
+    
+    engine.syncItemStates()
+    .always {
+      expectation.fulfill()
+    }.error { err in
+      print("got an error", err)
+    }
+    
+    waitForExpectationsWithTimeout(5) { _ in
+      let feed = self.db.feedWithID(self.feedID)
+      XCTAssert(feed!.items.first!.state == .InProgress(position: 5.5))
+    }
+  }
+}


### PR DESCRIPTION
For server-side details see: https://github.com/cjlucas/unnamedcast/issues/24

Currently, whenever `SyncEngine.updateItemState` is called, the value is persisted in the local DB, and then the entire array of item states is uploaded to the server. With these new endpoints, the client will be able to sync item states more efficiently.
## Proposed Changes

Currently, `updateItemState` tightly couples a database write with a reaction to upload to the server. We can take a more passive approach where the caller will update the item state directly through `DB` and the `SyncEngine` would observe this change through Realm's notification system. This would allow `SyncEngine` to be more resilient in unstable network conditions as well. ~~Once the `SyncEngine` recognizes a change in an item state, it would attempt to update that _single_ item state. If the client is offline, the `SyncEngine` could persist an array of item states that are to be synced, which can then be synced when the client is online.~~

Another option would be to store a modification time in `ItemState` and have the `SyncEngine` periodically scan for new item states and sync any newly modified states. More research is necessary but if a user has a massive amount of items, the time it would take to scan for recently modified states may be computationally non-trivial.

**Update:** Went for the later solution as the first one was overly complex. It will work gracefully in offline mode as well, where the client can continue to update it's states locally while not requiring any bookkeeping by the sync engine.
### Graceful Conflict Handling

Because the state on the server will have a modification timestamp associated with it, `SyncEngine` could compare modification timestamps and choose the most recently modified state as the winner.
